### PR TITLE
Add support for `allowDashes`

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -9,7 +9,7 @@
   "requireQuotedKeysInObjects": true,
   "disallowQuotedKeysInObjects": false,
   "maximumLineLength": {
-    "value": 79,
+    "value": 80,
     "allExcept": [
       "regex",
       "urlComments"

--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ var T_WHITE_SPACE = 'WhiteSpaceNode';
 function search(tree, phrases, handler, options) {
     var settings = options || {};
     var apos = settings.allowApostrophes || options;
+    var dashes = settings.allowDashes || false;
     var literals = settings.allowLiterals;
     var byWord = {};
     var length;
@@ -62,7 +63,7 @@ function search(tree, phrases, handler, options) {
      * @param {string} phrase - Phrase to search for.
      */
     function handlePhrase(phrase) {
-        firstWord = normalize(phrase.split(C_SPACE, 1)[0], apos);
+        firstWord = normalize(phrase.split(C_SPACE, 1)[0], apos, dashes);
 
         if (has.call(byWord, firstWord)) {
             byWord[firstWord].push(phrase);
@@ -147,7 +148,8 @@ function search(tree, phrases, handler, options) {
             if (
                 !node ||
                 node.type !== T_WORD ||
-                normalize(expression[index], apos) !== normalize(node, apos)
+                normalize(expression[index], apos, dashes) !==
+                normalize(node, apos, dashes)
             ) {
                 return null;
             }
@@ -178,7 +180,7 @@ function search(tree, phrases, handler, options) {
             return;
         }
 
-        word = normalize(node, apos);
+        word = normalize(node, apos, dashes);
         phrases = has.call(byWord, word) ? byWord[word] : [];
         length = phrases.length;
         index = -1;

--- a/index.js
+++ b/index.js
@@ -63,7 +63,10 @@ function search(tree, phrases, handler, options) {
      * @param {string} phrase - Phrase to search for.
      */
     function handlePhrase(phrase) {
-        firstWord = normalize(phrase.split(C_SPACE, 1)[0], apos, dashes);
+        firstWord = normalize(phrase.split(C_SPACE, 1)[0], {
+            'allowApostrophes': apos,
+            'allowDashes': dashes
+        });
 
         if (has.call(byWord, firstWord)) {
             byWord[firstWord].push(phrase);
@@ -148,8 +151,15 @@ function search(tree, phrases, handler, options) {
             if (
                 !node ||
                 node.type !== T_WORD ||
-                normalize(expression[index], apos, dashes) !==
-                normalize(node, apos, dashes)
+                normalize(expression[index], {
+                    'allowApostrophes': apos,
+                    'allowDashes': dashes
+                })
+                !==
+                normalize(node, {
+                    'allowApostrophes': apos,
+                    'allowDashes': dashes
+                })
             ) {
                 return null;
             }
@@ -180,7 +190,10 @@ function search(tree, phrases, handler, options) {
             return;
         }
 
-        word = normalize(node, apos, dashes);
+        word = normalize(node, {
+            'allowApostrophes': apos,
+            'allowDashes': dashes
+        });
         phrases = has.call(byWord, word) ? byWord[word] : [];
         length = phrases.length;
         index = -1;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "nlcst-is-literal": "^1.0.0",
-    "nlcst-normalize": "../nlcst-normalize",
+    "nlcst-normalize": "^1.1.0",
     "unist-util-visit": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "nlcst-is-literal": "^1.0.0",
-    "nlcst-normalize": "^1.1.0",
+    "nlcst-normalize": "../nlcst-normalize",
     "unist-util-visit": "^1.0.0"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -190,6 +190,19 @@ var tree = {
                     'value': 'hell'
                 }
             ]
+        },
+        {
+            'type': 'WhiteSpaceNode',
+            'value': ' '
+        },
+        {
+            'type': 'WordNode',
+            'children': [
+                {
+                    'type': 'TextNode',
+                    'value': 'selfservice'
+                }
+            ]
         }
     ]
 };
@@ -199,7 +212,7 @@ var tree = {
  */
 
 test('search(tree, patterns, handle)', function (t) {
-    t.plan(42);
+    t.plan(68);
 
     t.throws(
         function () {
@@ -274,7 +287,7 @@ test('search(tree, patterns, handle)', function (t) {
 
     t.doesNotThrow(function () {
         search(tree, ['or that']);
-    }, 'should not include non-word and non-white-space nodes');
+    }, 'shouldn’t include non-word and non-white-space nodes');
 
     var phrases = ['that or this', 'that'];
 
@@ -292,13 +305,125 @@ test('search(tree, patterns, handle)', function (t) {
         t.equal(phrase, match[3], 'should pass the phrase (phrases)');
     });
 
+    // handler function is only invoked if match is found
+    // search will throw if a match is found and no handler is provided
+    // the tree contains “hell” but not “he’ll” or “he'll”
+
+    t.throws(function () {
+        search(tree, ['hell'], null);
+    }, 'should find non-apostrophe words when `allowApostrophes` is absent');
+
+    t.throws(function () {
+        search(tree, ['he’ll'], null);
+    }, 'should find smart apostrophe words when `allowApostrophes` is absent');
+
+    t.throws(function () {
+        search(tree, ['he\'ll'], null);
+    }, 'should find dumb apostrophe words when `allowApostrophes` is absent');
+
+    t.throws(function () {
+        search(tree, ['hell'], null, true);
+    }, 'should find non-apostrophe words when `allowApostrophes` is true');
+
     t.doesNotThrow(function () {
         search(tree, ['he’ll'], null, true);
-    }, 'should not find non-apostrophe words when `allowApostrophes` is true');
+    }, 'shouldn’t find smart apostrophe words when `allowApostrophes` is true');
+
+    t.doesNotThrow(function () {
+        search(tree, ['he\'ll'], null, true);
+    }, 'shouldn’t find dumb apostrophe words when `allowApostrophes` is true');
+
+    t.throws(function () {
+        search(tree, ['hell'], null, false);
+    }, 'should find non-apostrophe words when `allowApostrophes` is false');
+
+    t.throws(function () {
+        search(tree, ['he’ll'], null, false);
+    }, 'should find smart apostrophe words when `allowApostrophes` is false');
+
+    t.throws(function () {
+        search(tree, ['he\'ll'], null, false);
+    }, 'should find dumb apostrophe words when `allowApostrophes` is false');
+
+    // the tree contains “selfservice” but not “self-service”
+
+    // jscs:disable maximumLineLength
+    t.throws(function () {
+        search(tree, ['selfservice'], null);
+    }, 'should find non-dash words when `allowDashes` is absent and `allowApostrophes` is absent');
+
+    t.throws(function () {
+        search(tree, ['self-service'], null);
+    }, 'should find dash words when `allowDashes` is absent and `allowApostrophes` is absent');
+
+    t.throws(function () {
+        search(tree, ['selfservice'], null, false);
+    }, 'should find non-dash words when `allowDashes` is absent and `allowApostrophes` is false');
+
+    t.throws(function () {
+        search(tree, ['self-service'], null, false);
+    }, 'should find dash words when `allowDashes` is absent and `allowApostrophes` is false');
+
+    t.throws(function () {
+        search(tree, ['selfservice'], null, true);
+    }, 'should find non-dash words when `allowDashes` is absent and `allowApostrophes` is true');
+
+    t.throws(function () {
+        search(tree, ['self-service'], null, true);
+    }, 'should find dash words when `allowDashes` is absent and `allowApostrophes` is true');
+
+    t.throws(function () {
+        search(tree, ['selfservice'], null, {'allowDashes': true});
+    }, 'should find non-dash words when `allowDashes` is true');
+
+    t.doesNotThrow(function () {
+        search(tree, ['self-service'], null, {'allowDashes': true});
+    }, 'shouldn’t find dash words when `allowDashes` is true');
+
+    t.throws(function () {
+        search(tree, ['selfservice'], null, {'allowDashes': false});
+    }, 'should find non-dash words when `allowDashes` is false');
+
+    t.throws(function () {
+        search(tree, ['self-service'], null, {'allowDashes': false});
+    }, 'should find dash words when `allowDashes` is false');
+
+    t.throws(function () {
+        search(tree, ['selfservice'], null, {'allowApostrophes': false, 'allowDashes': true});
+    }, 'should find non-dash words when `allowDashes` is true and `allowApostrophes` is false');
+
+    t.doesNotThrow(function () {
+        search(tree, ['self-service'], null, {'allowApostrophes': false, 'allowDashes': true});
+    }, 'shouldn’t find dash words when `allowDashes` is true and `allowApostrophes` is false');
+
+    t.throws(function () {
+        search(tree, ['selfservice'], null, {'allowApostrophes': false, 'allowDashes': false});
+    }, 'should find non-dash words when `allowDashes` is false and `allowApostrophes` is false');
+
+    t.throws(function () {
+        search(tree, ['self-service'], null, {'allowApostrophes': false, 'allowDashes': false});
+    }, 'should find dash words when `allowDashes` is false and `allowApostrophes` is false');
+
+    t.throws(function () {
+        search(tree, ['selfservice'], null, {'allowApostrophes': true, 'allowDashes': true});
+    }, 'should find non-dash words when `allowDashes` is true and `allowApostrophes` is true');
+
+    t.doesNotThrow(function () {
+        search(tree, ['self-service'], null, {'allowApostrophes': true, 'allowDashes': true});
+    }, 'shouldn’t find dash words when `allowDashes` is true and `allowApostrophes` is true');
+
+    t.throws(function () {
+        search(tree, ['selfservice'], null, {'allowApostrophes': true, 'allowDashes': false});
+    }, 'should find non-dash words when `allowDashes` is false and `allowApostrophes` is true');
+
+    t.throws(function () {
+        search(tree, ['self-service'], null, {'allowApostrophes': true, 'allowDashes': false});
+    }, 'should find dash words when `allowDashes` is false and `allowApostrophes` is true');
+    // jscs:enable maximumLineLength
 
     t.doesNotThrow(function () {
         search(tree, ['mellow']);
-    }, 'should not find literals by default');
+    }, 'shouldn’t find literals by default');
 
     search(tree, ['mellow'], function () {
         t.pass('should find literals when given `allowLiterals`');


### PR DESCRIPTION
## Problem

We want `retext-shopify`, which is based on `retext-simplify`, not to strip out hyphens when performing matches. For instance, we want to be able to tell people that `drop-down menu` is the preferred spelling, rather than `drop down menu` or `dropdown menu`.
## Solution

We added the ability to set `allowDashes` value (see https://github.com/wooorm/nlcst-normalize/pull/1 ) when calling the `search()` function.
## Notes

As in https://github.com/wooorm/nlcst-normalize/pull/1, Dave notes that the test coverage may be excessive, but since he used these tests to resolve the problem I was having, he left them in there.
